### PR TITLE
Correcting the name of secret generation directory in Makefile

### DIFF
--- a/Makefile-CSI
+++ b/Makefile-CSI
@@ -1,6 +1,6 @@
 PLATFORM=PLATFORM
 export GOPATH:=$(GOPATH):$(shell pwd)
-
+$(info ${GOPATH})
 all:COMMON_1 DIFF 
 
 COMMON_1:
@@ -9,10 +9,10 @@ COMMON_1:
 DIFF:
 ifeq (${PLATFORM}, X86)
 	go build -o ./bin/huawei-csi	  ./src/csi
-	go build -o ./bin/passwdEncrypt	  ./src/tools/passwdEncrypt
+	go build -o ./bin/secretGenerate  ./src/tools/secretGenerate
 endif
 
 ifeq (${PLATFORM}, ARM)
 	GOOS=linux GOARCH=arm64 go build -o ./bin/huawei-csi	  ./src/csi
-	GOOS=linux GOARCH=arm64 go build -o ./bin/passwdEncrypt	  ./src/tools/passwdEncrypt
+	GOOS=linux GOARCH=arm64 go build -o ./bin/secretGenerate  ./src/tools/secretGenerate
 endif


### PR DESCRIPTION
The secret generation dir name has changed to secretGenerate from passwdEncrypt.
Correcting Makefile for the same