### PR TITLE
 Raw Block Volume support (volume provisioning)

### DIFF
--- a/src/csi/backend/plugin/fusionstorage-san.go
+++ b/src/csi/backend/plugin/fusionstorage-san.go
@@ -158,6 +158,20 @@ func (p *FusionStorageSanPlugin) StageVolume(name string, parameters map[string]
 		return err
 	}
 
+	// If the request to stage is for volumeDevice of type Block and the devicePath
+	// is provided then do not format and create FS and mount it.
+	// Simply create a symlink to the devpath on the staging area
+	if parameters["volumeMode"].(string) == "Block" {
+		log.Infof("The request to stage raw block device")
+		mountpoint := parameters["stagingPath"].(string)
+		err := utils.CreateSymlink(devPath, mountpoint)
+		if nil != err {
+			log.Errorf("Error in staging device")
+			return err
+		}
+		return nil
+	}
+
 	return p.lunStageVolume(name, devPath, parameters)
 }
 

--- a/src/csi/backend/plugin/fusionstorage-san.go
+++ b/src/csi/backend/plugin/fusionstorage-san.go
@@ -161,9 +161,14 @@ func (p *FusionStorageSanPlugin) StageVolume(name string, parameters map[string]
 	// If the request to stage is for volumeDevice of type Block and the devicePath
 	// is provided then do not format and create FS and mount it.
 	// Simply create a symlink to the devpath on the staging area
-	if parameters["volumeMode"].(string) == "Block" {
+	if volMode, ok := parameters["volumeMode"].(string); ok && volMode == "Block" {
 		log.Infof("The request to stage raw block device")
-		mountpoint := parameters["stagingPath"].(string)
+		mountpoint, ok := parameters["stagingPath"].(string)
+		if !ok {
+			errMsg := "Error in getting staging path"
+			log.Errorf(errMsg)
+			return errors.New(errMsg)
+		}
 		err := utils.CreateSymlink(devPath, mountpoint)
 		if nil != err {
 			log.Errorf("Error in staging device")

--- a/src/csi/backend/plugin/oceanstor-san.go
+++ b/src/csi/backend/plugin/oceanstor-san.go
@@ -270,24 +270,10 @@ func (p *OceanstorSanPlugin) StageVolume(name string, parameters map[string]inte
 	if parameters["volumeMode"].(string) == "Block" {
 		log.Infof("The request to stage raw block device")
 		mountpoint := parameters["stagingPath"].(string)
-		// First check if File exists in the staging area, then remove the mount
-		// and then create a symlink to the devpath
-		_, err := os.Lstat(mountpoint)
-		if nil != err && os.IsNotExist(err) {
-			log.Infof("Mountpoint [%v] does not exist", mountpoint)
-		} else {
-			// delete the mount. The mountpoint deleted here is folder or soft link
-			_, err := utils.ExecShellCmd("rm -rf %s", mountpoint)
-			if nil != err {
-				log.Errorf("Failed to delete the mountpoint [%v] while staging rbd", mountpoint)
-				return err
-			}
-		}
 		devpath := out[0].Interface().(string)
-		err = os.Symlink(devpath, mountpoint)
+		err := utils.CreateSymlink(devpath, mountpoint)
 		if nil != err {
-			log.Errorf("Failed to create a link for devpath [%v] to stagingpath [%v]",
-					devpath, mountpoint)
+			log.Errorf("Error in staging device")
 			return err
 		}
 	}

--- a/src/csi/backend/plugin/oceanstor-san.go
+++ b/src/csi/backend/plugin/oceanstor-san.go
@@ -276,6 +276,7 @@ func (p *OceanstorSanPlugin) StageVolume(name string, parameters map[string]inte
 			log.Errorf("Error in staging device")
 			return err
 		}
+		return nil
 	}
 	return p.lunStageVolume(name, out[0].Interface().(string), parameters)
 }

--- a/src/csi/backend/plugin/oceanstor-san.go
+++ b/src/csi/backend/plugin/oceanstor-san.go
@@ -267,10 +267,20 @@ func (p *OceanstorSanPlugin) StageVolume(name string, parameters map[string]inte
 	// If the request to stage is for volumeDevice of type Block and the devicePath
 	// is provided then do not format and create FS and mount it.
 	// Simply create a symlink to the devpath on the staging area
-	if parameters["volumeMode"].(string) == "Block" {
+	if volMode, ok := parameters["volumeMode"].(string); ok && volMode == "Block" {
 		log.Infof("The request to stage raw block device")
-		mountpoint := parameters["stagingPath"].(string)
-		devpath := out[0].Interface().(string)
+		mountpoint, ok := parameters["stagingPath"].(string)
+		if !ok {
+			errMsg := "Error in getting staging path"
+			log.Errorf(errMsg)
+			return errors.New(errMsg)
+		}
+		devpath, ok := out[0].Interface().(string)
+		if !ok {
+			errMsg := "Error in getting devpath"
+			log.Errorf(errMsg)
+			return errors.New(errMsg)
+		}
 		err := utils.CreateSymlink(devpath, mountpoint)
 		if nil != err {
 			log.Errorf("Error in staging device")

--- a/src/csi/backend/plugin/oceanstor-san.go
+++ b/src/csi/backend/plugin/oceanstor-san.go
@@ -266,7 +266,7 @@ func (p *OceanstorSanPlugin) StageVolume(name string, parameters map[string]inte
 
 	// If the request to stage is for volumeDevice of type Block and the devicePath
 	// is provided then do not format and create FS and mount it.
-    // Simply create a symlink to the devpath on the staging area
+	// Simply create a symlink to the devpath on the staging area
 	if parameters["volumeMode"].(string) == "Block" {
 		log.Infof("The request to stage raw block device")
 		mountpoint := parameters["stagingPath"].(string)

--- a/src/csi/driver/node.go
+++ b/src/csi/driver/node.go
@@ -157,7 +157,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	// volume is Block or Mount. So check if it's symlink (which may get created for RBD)
 	//  and delete the symlink
 	symErr := utils.RemoveSymlink(targetPath)
-	if symErr != nil && !strings.Contains(symErr.Error(), "not a symbolic link") {
+	if symErr != nil {
 		output, err := utils.ExecShellCmd("umount %s", targetPath)
 		if err != nil && !strings.Contains(output, "not mounted") {
 			msg := fmt.Sprintf("umount %s for volume %s error: %s", targetPath, volumeId, output)

--- a/src/csi/driver/node.go
+++ b/src/csi/driver/node.go
@@ -8,7 +8,6 @@ import (
 	"csi/backend"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"utils"
 	"utils/log"
@@ -38,9 +37,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	mnt := req.GetVolumeCapability().GetMount()
-    blk := req.GetVolumeCapability().GetBlock()
+	blk := req.GetVolumeCapability().GetBlock()
 
-	var parameters = nil
+	var parameters = map[string]interface{}{}
 
 	if blk == nil {
 	    log.Infof("The request is to create volume of type filesystem")

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -530,6 +530,7 @@ func CreateSymlink(source string, target string) error {
 			return err
 		}
 	}
+	log.Infof("Creating symlink for [%s] to [%s]", source, target)
 	err = os.Symlink(source, target)
 	if nil != err {
 		log.Errorf("Failed to create a link for [%v] to  [%v]",

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -514,3 +514,27 @@ func NeedMultiPath(backendConfigs []map[string]interface{}) bool {
 
 	return needMultiPath
 }
+
+// Create a symlink
+func CreateSymlink(source string, target string) error {
+	// First check if File exists in the staging area, then remove the mount
+	// and then create a symlink to the devpath
+	_, err := os.Lstat(target)
+	if nil != err && os.IsNotExist(err) {
+		log.Infof("Mountpoint [%v] does not exist", target)
+	} else {
+		// delete the mount. The mountpoint deleted here is folder or soft link
+		_, err := utils.ExecShellCmd("rm -rf %s", target)
+		if nil != err {
+			log.Errorf("Failed to delete the mountpoint [%v] while staging rbd", target)
+			return err
+		}
+	}
+	err = os.Symlink(source, target)
+	if nil != err {
+		log.Errorf("Failed to create a link for [%v] to  [%v]",
+				source, target)
+		return err
+	}
+	return nil
+}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -524,9 +524,9 @@ func CreateSymlink(source string, target string) error {
 		log.Infof("Mountpoint [%v] does not exist", target)
 	} else {
 		// delete the mount. The mountpoint deleted here is folder or soft link
-		_, err := utils.ExecShellCmd("rm -rf %s", target)
+		_, err := ExecShellCmd("rm -rf %s", target)
 		if nil != err {
-			log.Errorf("Failed to delete the mountpoint [%v] while staging rbd", target)
+			log.Errorf("Failed to delete the target [%v]", target)
 			return err
 		}
 	}
@@ -535,6 +535,29 @@ func CreateSymlink(source string, target string) error {
 		log.Errorf("Failed to create a link for [%v] to  [%v]",
 				source, target)
 		return err
+	}
+	return nil
+}
+
+// Remove symlink
+func RemoveSymlink(target string) error {
+	finfo, err := os.Lstat(target)
+	if nil != err && os.IsNotExist(err) {
+		log.Infof("target symlink [%v] does not exist", target)
+		return err
+	}
+	// If the file is symlink delete it
+	if finfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+		_, clierr := ExecShellCmd("rm -rf %s", target)
+		if nil != clierr {
+			log.Errorf("Failed to delete the target [%v]", target)
+			return clierr
+		} else {
+			log.Infof("Successfully deleted the target [%v]", target)
+		}
+	} else {
+		msg := fmt.Sprint("not a symbolic link")
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/yamls/example/pod-with-rbd-example.yaml
+++ b/yamls/example/pod-with-rbd-example.yaml
@@ -1,0 +1,15 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: mypod
+spec:
+  containers:
+    - name: mycontainer
+      image: ******
+      volumeDevices:
+        - name: mypv
+          devicePath: "/dev/xvda"
+  volumes:
+    - name: mypv
+      persistentVolumeClaim:
+        claimName: mypvc

--- a/yamls/example/pvc-rbd-example.yaml
+++ b/yamls/example/pvc-rbd-example.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mypvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Block
+  storageClassName: mysc
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
#### What this PR does / Why we need it:
The changes related to create and delete volume and then stage/unstage on the node and publish/unpublish it to the app.

- [x]  Support for Create Volume
- [x] Support for RBD attached to POD
- [x] Support for Delete Volume
- [x] Support for RBD detach from POD
- [x] Multipath as well as non-multipath test
- [ ] UT


#### Tests Done:
a) Create volume, publish volume to POD [Oceanstor SAN]
b) Delete volume, unpublish volume from POD [Oceanstor SAN]
c) Create volume, publish volume to POD [Fusionstorage SAN]
d) Delete volume, unpublish volume from POD [Fusionstorage SAN]
e) Verified that pod gets the RBD as block disk 
f) Verified the volume creation and mapping from storage side
g) Verified provisioning and de-provisioning from the node
