### PR TITLE
Support NVMe_FC protocol

### DIFF
--- a/src/connector/connector_utils.go
+++ b/src/connector/connector_utils.go
@@ -948,3 +948,26 @@ func RemoveRoCEDevice(device string) ([]string, string, error) {
 
 	return devices, multiPathName, nil
 }
+
+// RemoveNvmeFcDevice remove dm device if present
+func RemoveNvmeFcDevice(device string) (string, error) {
+	var multiPathName string
+	var err error
+	if strings.HasPrefix(device, "dm") {
+		multiPathName = device
+		// devices: nvme0n1, nvme2n1,
+		_, err = getDeviceFromDM(multiPathName)
+		if err != nil {
+			log.Warningf("Get the devices from the multipath %s error: %v", multiPathName, err)
+		}
+
+		// just flush the dm path. no need to delete device on host, when delete the storage mapping
+		// the device will be automatically deleted.
+		err := FlushDMDevice(multiPathName)
+		if err == nil {
+			multiPathName = ""
+		}
+	}
+
+	return multiPathName, nil
+}

--- a/src/connector/nvme/nvme_helper.go
+++ b/src/connector/nvme/nvme_helper.go
@@ -1,0 +1,31 @@
+package nvme
+
+import (
+	"connector"
+	"time"
+	"utils/log"
+)
+
+func tryDisConnectVolume(tgtLunWWN string, checkDeviceAvailable bool) error {
+	device, err := connector.GetDevice(nil, tgtLunWWN, checkDeviceAvailable)
+	if err != nil {
+		log.Warningf("Get device of WWN %s error: %v", tgtLunWWN, err)
+		return err
+	}
+
+	multiPathName, err := connector.RemoveNvmeFcDevice(device)
+	if err != nil {
+		log.Errorf("Remove device %s error: %v", device, err)
+		return err
+	}
+
+	if multiPathName != "" {
+		time.Sleep(time.Second * intNumThree)
+		err = connector.FlushDMDevice(device)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/yamls/deploy/huawei-csi-configmap-oceanstor-fcnvme.yaml
+++ b/yamls/deploy/huawei-csi-configmap-oceanstor-fcnvme.yaml
@@ -1,0 +1,18 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: huawei-csi-configmap
+  namespace: kube-system
+data:
+  csi.json: |
+    {
+        "backends": [
+            {
+                "storage": "oceanstor-san",
+                "name": "***",
+                "urls": ["https://*.*.*.*:8088", "https://*.*.*.*:8088"],
+                "pools": ["***", "***"],
+                "parameters": {"protocol": "fc-nvme"}
+            }
+        ]
+    }


### PR DESCRIPTION
This PR addresses the changes required in current code base to support NVMe over FC protocol.
Current framework already has code to handle some part of the support

Unit test to be added to this PR

Key scenarios tested:
Volume create/delete
POD create/delete
Volume expand
Volume clone
Volume snapshot
Support DM multipath and single path
Data write on pvc
Node restart scenarios
