### PR TITLE
fix error log when get volume metrics

### DIFF
--- a/csi/driver/node.go
+++ b/csi/driver/node.go
@@ -290,7 +290,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 
 	volumeMetrics, err := utils.GetVolumeMetrics(VolumePath)
 	if err != nil {
-		msg := fmt.Sprintf("get volume metrics failed, reason %v", volumeMetrics)
+		msg := fmt.Sprintf("get volume metrics failed, reason %v", err)
 		log.AddContext(ctx).Errorln(msg)
 		return nil, status.Error(codes.Internal, msg)
 	}


### PR DESCRIPTION
It seems a typo when `err != nil`. It's unless to return volumeMetrics when `err != nil`.