### PR TITLE
Add imagePullSecrets to helm chart for huawei images

### DIFF
--- a/helm/esdk/templates/huawei-csi-controller.yaml
+++ b/helm/esdk/templates/huawei-csi-controller.yaml
@@ -480,6 +480,10 @@ spec:
       {{ end }}
       hostNetwork: true
       serviceAccount: huawei-csi-controller
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: liveness-probe
           args:

--- a/helm/esdk/templates/huawei-csi-node.yaml
+++ b/helm/esdk/templates/huawei-csi-node.yaml
@@ -105,6 +105,10 @@ spec:
       tolerations:
       {{- toYaml .Values.node.tolerations | nindent 6 }}
       {{ end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: liveness-probe
           args:

--- a/helm/esdk/values.yaml
+++ b/helm/esdk/values.yaml
@@ -16,6 +16,10 @@ images:
     snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.0
     snapshotController: registry.k8s.io/sig-storage/snapshot-controller:v6.3.0
 
+# Name of image pull secrets for images bundled within eSDK
+imagePullSecrets: []
+# - name: imagepullsecretname
+
 # Default image pull policy for sidecar container images, support [IfNotPresent, Always, Never]
 sidecarImagePullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
Adds imagePullSecrets for pulling images from private registries as requested in #158
