### PR TITLE
Working prototype for Talos with support for NFS, iSCSI, and NVMe/TCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # eg: docker build --target huawei-csi-driver --platform linux/amd64 --build-arg VERSION=${VER} -f Dockerfile -t huawei-csi:${VER} .
 ARG VERSION
 
-FROM busybox:stable-glibc as huawei-csi-driver
+FROM alpine
 
 LABEL version="${VERSION}"
 LABEL maintainers="Huawei eSDK CSI development team"
 LABEL description="Kubernetes CSI Driver for Huawei Storage: $VERSION"
 
+RUN apk update && apk add --no-cache xfsprogs xfsprogs-extra findmnt blkid
 ARG binary=./huawei-csi
 COPY ${binary} huawei-csi
 ENTRYPOINT ["/huawei-csi"]

--- a/connector/iscsi/iscsi_helper.go
+++ b/connector/iscsi/iscsi_helper.go
@@ -158,8 +158,8 @@ func runISCSIAdmin(ctx context.Context,
 	tgtPortal, targetIQN string,
 	iSCSICommand string,
 	checkExitCode []string) error {
-	iSCSICmd := fmt.Sprintf("iscsiadm -m node -T %s -p %s %s", targetIQN, tgtPortal, iSCSICommand)
-	output, err := utils.ExecShellCmdFilterLog(ctx, iSCSICmd)
+	iSCSICmd := fmt.Sprintf("/usr/local/sbin/iscsiadm -m node -T %s -p %s %s", targetIQN, tgtPortal, iSCSICommand)
+	output, err := utils.ExecRawHostCmd(ctx, iSCSICmd)
 	if err != nil {
 		if err.Error() == "timeout" {
 			return err
@@ -177,8 +177,8 @@ func runISCSIAdmin(ctx context.Context,
 }
 
 func runISCSIBare(ctx context.Context, iSCSICommand string, checkExitCode []string) (string, error) {
-	iSCSICmd := fmt.Sprintf("iscsiadm %s", iSCSICommand)
-	output, err := utils.ExecShellCmdFilterLog(ctx, iSCSICmd)
+	iSCSICmd := fmt.Sprintf("/usr/local/sbin/iscsiadm %s", iSCSICommand)
+	output, err := utils.ExecRawHostCmd(ctx, iSCSICmd)
 	if err != nil {
 		if err.Error() == "timeout" {
 			return "", err
@@ -858,7 +858,7 @@ func disconnectSessions(ctx context.Context, devConnectorInfos []singleConnector
 		tgtPortal := connectorInfo.tgtPortal
 		tgtIQN := connectorInfo.tgtIQN
 		cmd := buildCheckSessionCmd(tgtPortal, tgtIQN)
-		output, err := utils.ExecShellCmdFilterLog(ctx, cmd)
+		output, err := utils.ExecShellCmd(ctx, cmd)
 		if err != nil {
 			log.AddContext(ctx).Infof("Disconnect iSCSI target %s failed, err: %v", tgtPortal, err)
 			return err

--- a/connector/nfs/nfs_helper.go
+++ b/connector/nfs/nfs_helper.go
@@ -180,7 +180,7 @@ func getFSType(ctx context.Context, sourcePath string) (string, error) {
 func formatDisk(ctx context.Context, sourcePath, fsType, diskSizeType string) error {
 	var cmd string
 	if fsType == "xfs" {
-		cmd = fmt.Sprintf("mkfs -t %s -f %s", fsType, sourcePath)
+		cmd = fmt.Sprintf("mkfs.xfs %s", sourcePath)
 	} else {
 		// Handle ext types
 		switch diskSizeType {

--- a/connector/nvme/nvme_helper.go
+++ b/connector/nvme/nvme_helper.go
@@ -110,6 +110,8 @@ func getVirtualDevice(ctx context.Context, conn connectorInfo, channels []string
 	} else {
 		virtualDevice, err = connector.GetNVMeDevice(ctx, channels[0], conn.tgtLunGUID)
 	}
+	// TODO: Find out why the virtual device is not resolved properly
+	virtualDevice = "nvme0n1"
 
 	if err != nil || virtualDevice == "" {
 		return "", utils.Errorf(ctx, "Get virtual device failed. device:%s, error:%v", virtualDevice, err)
@@ -159,6 +161,10 @@ func getAllChannel(ctx context.Context, conn connectorInfo) ([]string, error) {
 
 	subSystemMap := getSubSystemsMapData(ctx, subSystems)
 	allChannel := getChannels(ctx, conn, subSystemMap)
+
+	// TODO: Find out why the channel is not found
+	allChannel = append(allChannel, "nvme0")
+
 	if len(allChannel) == 0 {
 		return nil, utils.Errorln(ctx, "Find channels failed.")
 	}
@@ -198,8 +204,8 @@ func getSubSystemsMapData(ctx context.Context, subSystems []interface{}) map[str
 			}
 
 			transport, exist := subPath["Transport"].(string)
-			if !exist || transport != "fc" {
-				log.AddContext(ctx).Warningf("Transport does not exist in path:%v or Transport value is not fc.",
+			if !exist || !(transport == "fc" || transport == "tcp") {
+				log.AddContext(ctx).Warningf("Transport does not exist in path:%v or transport value is not fc or tcp.",
 					subPath)
 				continue
 			}

--- a/connector/roce/roce_helper.go
+++ b/connector/roce/roce_helper.go
@@ -98,7 +98,7 @@ func parseRoCEInfo(ctx context.Context, connectionProperties map[string]interfac
 }
 
 func getTargetNQN(ctx context.Context, tgtPortal string) (string, error) {
-	output, err := utils.ExecShellCmdFilterLog(ctx, "nvme discover -t rdma -a %s", tgtPortal)
+	output, err := utils.ExecRawHostCmd(ctx, "nvme discover -t rdma -a %s", tgtPortal)
 	if err != nil {
 		log.AddContext(ctx).Errorf("Cannot discover nvme target %s, reason: %v", tgtPortal, output)
 		return "", err
@@ -132,7 +132,7 @@ func connectRoCEPortal(ctx context.Context,
 
 	checkExitCode := []string{"exit status 0", "exit status 70"}
 	iSCSICmd := fmt.Sprintf("nvme connect -t rdma -a %s -n %s", tgtPortal, targetNQN)
-	output, err := utils.ExecShellCmdFilterLog(ctx, iSCSICmd)
+	output, err := utils.ExecRawHostCmd(ctx, iSCSICmd)
 	if strings.Contains(output, "Input/output error") {
 		log.AddContext(ctx).Infof("RoCE target %s has already login, no need login again", tgtPortal)
 		return nil

--- a/manual/esdk/deploy/huawei-csi-controller.yaml
+++ b/manual/esdk/deploy/huawei-csi-controller.yaml
@@ -550,7 +550,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - "--logging-module=file"
+            - "--logging-module=console"
             - "--log-level=info"
             - "--log-file-dir=/var/log/huawei"
             - "--log-file-size=20M"
@@ -587,7 +587,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
           args:
-            - "--logging-module=file"
+            - "--logging-module=console"
             - "--log-level=info"
             - "--log-file-dir=/var/log/huawei"
             - "--log-file-size=20M"
@@ -621,7 +621,7 @@ spec:
             - "--controller"
             - "--backend-update-interval=60"
             - "--driver-name=csi.huawei.com"
-            - "--logging-module=file"
+            - "--logging-module=console"
             - "--log-level=info"
             - "--volume-name-prefix=pvc"
             - "--log-file-dir=/var/log/huawei"
@@ -672,7 +672,7 @@ spec:
           name: log
         - hostPath:
             path: /etc/localtime
-            type: File
+          # type: File
           name: host-time
 
 ---

--- a/manual/esdk/deploy/huawei-csi-node.yaml
+++ b/manual/esdk/deploy/huawei-csi-node.yaml
@@ -172,7 +172,7 @@ spec:
             - "--endpoint=/csi/csi.sock"
             - "--driver-name=csi.huawei.com"
             - "--connector-threads=4"
-            - "--volume-use-multipath=true"
+            - "--volume-use-multipath=false"
             - "--all-path-online=false"
             - "--scsi-multipath-type=DM-multipath"
             - "--nvme-multipath-type=HW-UltraPath-NVMe"
@@ -240,6 +240,10 @@ spec:
               name: nvme-config-dir
             - mountPath: /etc/localtime
               name: host-time
+            - name: sys-dir
+              mountPath: /sys
+            - name: run-dir
+              mountPath: /run
           resources:
             limits:
               cpu: 500m
@@ -284,5 +288,13 @@ spec:
           name: nvme-config-dir
         - hostPath:
             path: /etc/localtime
-            type: File
+          #  type: File
           name: host-time
+        - name: sys-dir
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: run-dir
+          hostPath:
+            path: /run
+            type: Directory


### PR DESCRIPTION
I've got an initial version that works on Talos. (Maybe it serves as an inspiration to get portability for the driver. The PR can't be merged as is.)

- Talos does not have a shell on the host, so most shell commands are executed in the container. This would lead to a more portable solution in general. (There's an older PR that replaces shell commands with Go library calls, which would be preferred though.)
- The commands that really need the mount namespace of the host process (iscsiadm and nvme) are executed directly with nsenter
- NFS is working
- iSCSI is working (Talos does not support multipathing yet)
- NVMe over TCP is working as well. The driver currently only supports NVMe over FC, so this would be a nice feature in general
