### PR TITLE
Fix[helm]: storage-backend-sidecar: webhooks[0].clientConfig.service.port: Invalid value: 0

### DIFF
--- a/helm/esdk/templates/huawei-csi-controller.yaml
+++ b/helm/esdk/templates/huawei-csi-controller.yaml
@@ -663,6 +663,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - "--logging-module={{ ((.Values.csiDriver).controllerLogging).module | default "file" }}"
             - "--log-level={{ ((.Values.csiDriver).controllerLogging).level | default "info" }}"
@@ -671,6 +675,8 @@ spec:
             - "--max-backups={{ int ((.Values.csiDriver).controllerLogging).maxBackups | default 9 }}"
             - "--backend-update-interval={{ .Values.csiDriver.backendUpdateInterval }}"
             - "--dr-endpoint=$(DRCSI_ENDPOINT)"
+            - "--web-hook-port={{ int .Values.controller.webhookPort | default 4433 }}"
+            - "--web-hook-address=$(POD_IP)"
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/helm/esdk/templates/huawei-csi-controller.yaml
+++ b/helm/esdk/templates/huawei-csi-controller.yaml
@@ -610,6 +610,8 @@ spec:
           image: {{ required "Must provide the .Values.images.storageBackendController" .Values.images.storageBackendController }}
           imagePullPolicy: {{ .Values.huaweiImagePullPolicy }}
           env:
+            - name: DRCSI_ENDPOINT
+              value: {{ .Values.csiDriver.drEndpoint }}
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -627,6 +629,7 @@ spec:
             - "--max-backups={{ int ((.Values.csiDriver).controllerLogging).maxBackups | default 9 }}"
             - "--web-hook-port={{ int .Values.controller.webhookPort | default 4433 }}"
             - "--web-hook-address=$(POD_IP)"
+            - "--dr-endpoint=$(DRCSI_ENDPOINT)"
             {{ if gt ( (.Values.controller).controllerCount | int ) 1 }}
             - "--enable-leader-election=true"
             {{ else }}


### PR DESCRIPTION
When using helm chart to deploy the application I get the following error:

Back-off restarting failed container storage-backend-sidecar in pod huawei-csi-controller-6ddd7bf58d-fn6fv_huawei-csi

1 [ERROR]: [requestID:4037639093] create webhook configuration [storage-backend-controller.xuanwu.huawei.io] failed: ValidatingWebhookConfiguration.admissionregistration.k8s.io "storage-backend-controller.xuanwu.huawei.io" is invalid: webhooks[0].clientConfig.service.port: Invalid value: 0: port is not valid: must be between 1 and 65535, inclusive.

The error is caused by missing webhook args for the storage-backend-sidecar, which appear to be required.