### PR TITLE
Fix[helm]: storage-backend-sidecar and storage-backend-controller fail

### DIFF
--- a/helm/esdk/templates/huawei-csi-controller.yaml
+++ b/helm/esdk/templates/huawei-csi-controller.yaml
@@ -610,6 +610,8 @@ spec:
           image: {{ required "Must provide the .Values.images.storageBackendController" .Values.images.storageBackendController }}
           imagePullPolicy: {{ .Values.huaweiImagePullPolicy }}
           env:
+            - name: DRCSI_ENDPOINT
+              value: {{ .Values.csiDriver.drEndpoint }}
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -627,6 +629,7 @@ spec:
             - "--max-backups={{ int ((.Values.csiDriver).controllerLogging).maxBackups | default 9 }}"
             - "--web-hook-port={{ int .Values.controller.webhookPort | default 4433 }}"
             - "--web-hook-address=$(POD_IP)"
+            - "--dr-endpoint=$(DRCSI_ENDPOINT)"
             {{ if gt ( (.Values.controller).controllerCount | int ) 1 }}
             - "--enable-leader-election=true"
             {{ else }}
@@ -644,6 +647,8 @@ spec:
           ports:
             - containerPort: {{ int .Values.controller.webhookPort | default 4433 }}
           volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
             - mountPath: /var/log
               name: log
             - mountPath: /etc/localtime


### PR DESCRIPTION
When using helm chart v4.9.0 to deploy the application to the Kubernetes 1.33.4 I get the following errors:

1. **storage-backend-sidecar** failed with the following error:
`[ERROR]: [requestID:4037639093] create webhook configuration [storage-backend-controller.xuanwu.huawei.io] failed: ValidatingWebhookConfiguration.admissionregistration.k8s.io "storage-backend-controller.xuanwu.huawei.io" is invalid: webhooks[0].clientConfig.service.port: Invalid value: 0: port is not valid: must be between 1 and 65535, inclusive.` This is caused by missing webhook args for the storage-backend-sidecar, which appear to be required.

2. **storage-backend-controller** failed with the following error:
`still connecting to unix:///var/lib/kubelet/plugins/huawei.csi.driver/dr-csi.sock`. This is caused by missing shared `socket-dir` volume and `--dr-endpoint` arg.